### PR TITLE
Changed hll_add_agg() to return hll_empty instead of NULL

### DIFF
--- a/hll.c
+++ b/hll.c
@@ -2814,10 +2814,26 @@ hll_add_trans4(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_add_trans4 outside transition context")));
 
-    // Is the first argument a NULL?
+    // If the first argument is a NULL on first call, init an hll_empty
     if (PG_ARGISNULL(0))
     {
+        int32 log2m = PG_GETARG_INT32(2);
+        int32 regwidth = PG_GETARG_INT32(3);
+        int64 expthresh = PG_GETARG_INT64(4);
+        int32 sparseon = PG_GETARG_INT32(5);
+
         msap = setup_multiset(aggctx);
+
+        check_modifiers(log2m, regwidth, expthresh, sparseon);
+
+        memset(msap, '\0', sizeof(multiset_t));
+
+        msap->ms_type = MST_EMPTY;
+        msap->ms_nbits = regwidth;
+        msap->ms_nregs = 1 << log2m;
+        msap->ms_log2nregs = log2m;
+        msap->ms_expthresh = expthresh;
+        msap->ms_sparseon = sparseon;
     }
     else
     {
@@ -2828,28 +2844,6 @@ hll_add_trans4(PG_FUNCTION_ARGS)
     if (!PG_ARGISNULL(1))
     {
         int64 val = PG_GETARG_INT64(1);
-
-        // Was the first argument uninitialized?
-        if (msap->ms_type == MST_UNINIT)
-        {
-            int32 log2m = PG_GETARG_INT32(2);
-            int32 regwidth = PG_GETARG_INT32(3);
-            int64 expthresh = PG_GETARG_INT64(4);
-            int32 sparseon = PG_GETARG_INT32(5);
-
-            multiset_t	ms;
-
-            check_modifiers(log2m, regwidth, expthresh, sparseon);
-
-            memset(msap, '\0', sizeof(ms));
-
-            msap->ms_type = MST_EMPTY;
-            msap->ms_nbits = regwidth;
-            msap->ms_nregs = 1 << log2m;
-            msap->ms_log2nregs = log2m;
-            msap->ms_expthresh = expthresh;
-            msap->ms_sparseon = sparseon;
-        }
 
         multiset_add(msap, val);
     }
@@ -2877,10 +2871,26 @@ hll_add_trans3(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_add_trans3 outside transition context")));
 
-    // Is the first argument a NULL?
+    // If the first argument is a NULL on first call, init an hll_empty
     if (PG_ARGISNULL(0))
     {
+        int32 log2m = PG_GETARG_INT32(2);
+        int32 regwidth = PG_GETARG_INT32(3);
+        int64 expthresh = PG_GETARG_INT64(4);
+        int32 sparseon = g_default_sparseon;
+
         msap = setup_multiset(aggctx);
+
+        check_modifiers(log2m, regwidth, expthresh, sparseon);
+
+        memset(msap, '\0', sizeof(multiset_t));
+
+        msap->ms_type = MST_EMPTY;
+        msap->ms_nbits = regwidth;
+        msap->ms_nregs = 1 << log2m;
+        msap->ms_log2nregs = log2m;
+        msap->ms_expthresh = expthresh;
+        msap->ms_sparseon = sparseon;
     }
     else
     {
@@ -2891,28 +2901,6 @@ hll_add_trans3(PG_FUNCTION_ARGS)
     if (!PG_ARGISNULL(1))
     {
         int64 val = PG_GETARG_INT64(1);
-
-        // Was the first argument uninitialized?
-        if (msap->ms_type == MST_UNINIT)
-        {
-            int32 log2m = PG_GETARG_INT32(2);
-            int32 regwidth = PG_GETARG_INT32(3);
-            int64 expthresh = PG_GETARG_INT64(4);
-            int32 sparseon = g_default_sparseon;
-
-            multiset_t	ms;
-
-            check_modifiers(log2m, regwidth, expthresh, sparseon);
-
-            memset(msap, '\0', sizeof(ms));
-
-            msap->ms_type = MST_EMPTY;
-            msap->ms_nbits = regwidth;
-            msap->ms_nregs = 1 << log2m;
-            msap->ms_log2nregs = log2m;
-            msap->ms_expthresh = expthresh;
-            msap->ms_sparseon = sparseon;
-        }
 
         multiset_add(msap, val);
     }
@@ -2940,10 +2928,26 @@ hll_add_trans2(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_add_trans2 outside transition context")));
 
-    // Is the first argument a NULL?
+    // If the first argument is a NULL on first call, init an hll_empty
     if (PG_ARGISNULL(0))
     {
+        int32 log2m = PG_GETARG_INT32(2);
+        int32 regwidth = PG_GETARG_INT32(3);
+        int64 expthresh = g_default_expthresh;
+        int32 sparseon = g_default_sparseon;
+
         msap = setup_multiset(aggctx);
+
+        check_modifiers(log2m, regwidth, expthresh, sparseon);
+
+        memset(msap, '\0', sizeof(multiset_t));
+
+        msap->ms_type = MST_EMPTY;
+        msap->ms_nbits = regwidth;
+        msap->ms_nregs = 1 << log2m;
+        msap->ms_log2nregs = log2m;
+        msap->ms_expthresh = expthresh;
+        msap->ms_sparseon = sparseon;
     }
     else
     {
@@ -2954,28 +2958,6 @@ hll_add_trans2(PG_FUNCTION_ARGS)
     if (!PG_ARGISNULL(1))
     {
         int64 val = PG_GETARG_INT64(1);
-
-        // Was the first argument uninitialized?
-        if (msap->ms_type == MST_UNINIT)
-        {
-            int32 log2m = PG_GETARG_INT32(2);
-            int32 regwidth = PG_GETARG_INT32(3);
-            int64 expthresh = g_default_expthresh;
-            int32 sparseon = g_default_sparseon;
-
-            multiset_t	ms;
-
-            check_modifiers(log2m, regwidth, expthresh, sparseon);
-
-            memset(msap, '\0', sizeof(ms));
-
-            msap->ms_type = MST_EMPTY;
-            msap->ms_nbits = regwidth;
-            msap->ms_nregs = 1 << log2m;
-            msap->ms_log2nregs = log2m;
-            msap->ms_expthresh = expthresh;
-            msap->ms_sparseon = sparseon;
-        }
 
         multiset_add(msap, val);
     }
@@ -3003,10 +2985,26 @@ hll_add_trans1(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_add_trans1 outside transition context")));
 
-    // Is the first argument a NULL?
+    // If the first argument is a NULL on first call, init an hll_empty
     if (PG_ARGISNULL(0))
     {
+        int32 log2m = PG_GETARG_INT32(2);
+        int32 regwidth = g_default_regwidth;
+        int64 expthresh = g_default_expthresh;
+        int32 sparseon = g_default_sparseon;
+
         msap = setup_multiset(aggctx);
+
+        check_modifiers(log2m, regwidth, expthresh, sparseon);
+
+        memset(msap, '\0', sizeof(multiset_t));
+
+        msap->ms_type = MST_EMPTY;
+        msap->ms_nbits = regwidth;
+        msap->ms_nregs = 1 << log2m;
+        msap->ms_log2nregs = log2m;
+        msap->ms_expthresh = expthresh;
+        msap->ms_sparseon = sparseon;
     }
     else
     {
@@ -3017,28 +3015,6 @@ hll_add_trans1(PG_FUNCTION_ARGS)
     if (!PG_ARGISNULL(1))
     {
         int64 val = PG_GETARG_INT64(1);
-
-        // Was the first argument uninitialized?
-        if (msap->ms_type == MST_UNINIT)
-        {
-            int32 log2m = PG_GETARG_INT32(2);
-            int32 regwidth = g_default_regwidth;
-            int64 expthresh = g_default_expthresh;
-            int32 sparseon = g_default_sparseon;
-
-            multiset_t	ms;
-
-            check_modifiers(log2m, regwidth, expthresh, sparseon);
-
-            memset(msap, '\0', sizeof(ms));
-
-            msap->ms_type = MST_EMPTY;
-            msap->ms_nbits = regwidth;
-            msap->ms_nregs = 1 << log2m;
-            msap->ms_log2nregs = log2m;
-            msap->ms_expthresh = expthresh;
-            msap->ms_sparseon = sparseon;
-        }
 
         multiset_add(msap, val);
     }
@@ -3066,10 +3042,26 @@ hll_add_trans0(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_add_trans0 outside transition context")));
 
-    // Is the first argument a NULL?
+    // If the first argument is a NULL on first call, init an hll_empty
     if (PG_ARGISNULL(0))
     {
+        int32 log2m = g_default_log2m;
+        int32 regwidth = g_default_regwidth;
+        int64 expthresh = g_default_expthresh;
+        int32 sparseon = g_default_sparseon;
+
         msap = setup_multiset(aggctx);
+
+        check_modifiers(log2m, regwidth, expthresh, sparseon);
+
+        memset(msap, '\0', sizeof(multiset_t));
+
+        msap->ms_type = MST_EMPTY;
+        msap->ms_nbits = regwidth;
+        msap->ms_nregs = 1 << log2m;
+        msap->ms_log2nregs = log2m;
+        msap->ms_expthresh = expthresh;
+        msap->ms_sparseon = sparseon;
     }
     else
     {
@@ -3080,28 +3072,6 @@ hll_add_trans0(PG_FUNCTION_ARGS)
     if (!PG_ARGISNULL(1))
     {
         int64 val = PG_GETARG_INT64(1);
-
-        // Was the first argument uninitialized?
-        if (msap->ms_type == MST_UNINIT)
-        {
-            int32 log2m = g_default_log2m;
-            int32 regwidth = g_default_regwidth;
-            int64 expthresh = g_default_expthresh;
-            int32 sparseon = g_default_sparseon;
-
-            multiset_t	ms;
-
-            check_modifiers(log2m, regwidth, expthresh, sparseon);
-
-            memset(msap, '\0', sizeof(ms));
-
-            msap->ms_type = MST_EMPTY;
-            msap->ms_nbits = regwidth;
-            msap->ms_nregs = 1 << log2m;
-            msap->ms_log2nregs = log2m;
-            msap->ms_expthresh = expthresh;
-            msap->ms_sparseon = sparseon;
-        }
 
         multiset_add(msap, val);
     }

--- a/regress/add_agg.ref
+++ b/regress/add_agg.ref
@@ -115,5 +115,29 @@ select hll_print(hll_add_agg(NULL, 10));
  EMPTY, nregs=1024, nbits=5, expthresh=-1(80), sparseon=1
 (1 row)
 
+select hll_print(hll_add_agg(NULL, 10, 4));
+                        hll_print                         
+----------------------------------------------------------
+ EMPTY, nregs=1024, nbits=4, expthresh=-1(64), sparseon=1
+(1 row)
+
+select hll_print(hll_add_agg(NULL, 10, 4, 512));
+                       hll_print                       
+-------------------------------------------------------
+ EMPTY, nregs=1024, nbits=4, expthresh=512, sparseon=1
+(1 row)
+
+select hll_print(hll_add_agg(NULL, 10, 4, -1));
+                        hll_print                         
+----------------------------------------------------------
+ EMPTY, nregs=1024, nbits=4, expthresh=-1(64), sparseon=1
+(1 row)
+
+select hll_print(hll_add_agg(NULL, 10, 4, 512, 0));
+                       hll_print                       
+-------------------------------------------------------
+ EMPTY, nregs=1024, nbits=4, expthresh=512, sparseon=0
+(1 row)
+
 DROP TABLE test_khvengxf;
 DROP TABLE

--- a/regress/add_agg.ref
+++ b/regress/add_agg.ref
@@ -102,5 +102,18 @@ psql:add_agg.sql:56: ERROR:  sparseon modifier must be 0 or 1
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 512, 2))
        from test_khvengxf;
 psql:add_agg.sql:59: ERROR:  sparseon modifier must be 0 or 1
+-- Check that we return hll_empty on null input.
+select hll_print(hll_add_agg(NULL));
+                         hll_print                         
+-----------------------------------------------------------
+ EMPTY, nregs=2048, nbits=5, expthresh=-1(160), sparseon=1
+(1 row)
+
+select hll_print(hll_add_agg(NULL, 10));
+                        hll_print                         
+----------------------------------------------------------
+ EMPTY, nregs=1024, nbits=5, expthresh=-1(80), sparseon=1
+(1 row)
+
 DROP TABLE test_khvengxf;
 DROP TABLE

--- a/regress/add_agg.sql
+++ b/regress/add_agg.sql
@@ -64,4 +64,12 @@ select hll_print(hll_add_agg(NULL));
 
 select hll_print(hll_add_agg(NULL, 10));
 
+select hll_print(hll_add_agg(NULL, 10, 4));
+
+select hll_print(hll_add_agg(NULL, 10, 4, 512));
+
+select hll_print(hll_add_agg(NULL, 10, 4, -1));
+
+select hll_print(hll_add_agg(NULL, 10, 4, 512, 0));
+
 DROP TABLE test_khvengxf;

--- a/regress/add_agg.sql
+++ b/regress/add_agg.sql
@@ -58,4 +58,10 @@ select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 512, -1))
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 512, 2))
        from test_khvengxf;
 
+-- Check that we return hll_empty on null input.
+
+select hll_print(hll_add_agg(NULL));
+
+select hll_print(hll_add_agg(NULL, 10));
+
 DROP TABLE test_khvengxf;


### PR DESCRIPTION
Changed hll_add_trans() functions to return hll_empty instead of NULL when aggregating over empty sets. This makes hll_add_agg() conform to PostgreSQL's count() semantics over empty sets, and closes issue #2. Also added corresponding regression tests. (I didn't know if you'd like me to make changes to the documentation, so I left that as is.)
