### PR TITLE
Fix build portability issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ DATA =		\
 
 EXTRA_CLEAN += -r $(RPM_BUILD_ROOT)
 
-PG_CPPFLAGS += -fPIC
-PG_CPPFLAGS += -std=c99
+hll.o: override CFLAGS += -std=c99
+MurmurHash3.o: override CC = $(CXX)
 
 ifdef DEBUG
 COPT		+= -O0


### PR DESCRIPTION
Some platforms don't accept running c++ with the -std=c99 option.  Also,
adding the -fPIC option is not portable.  Instead, rely on the built-in
rules to build shared objects, and override the right flags per file.
