### PR TITLE
Binary input/output for HLL type. Fix compiler warnings. Remove logs from tests.

### DIFF
--- a/MurmurHash3.cpp
+++ b/MurmurHash3.cpp
@@ -34,7 +34,7 @@
 
 #else	// defined(_MSC_VER)
 
-#define	FORCE_INLINE __attribute__((always_inline))
+#define	FORCE_INLINE __attribute__((always_inline)) inline
 
 inline uint32_t rotl32 ( uint32_t x, int8_t r )
 {

--- a/hll--1.0.sql
+++ b/hll--1.0.sql
@@ -32,6 +32,16 @@ RETURNS cstring
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
 
+CREATE FUNCTION hll_recv(internal)
+RETURNS hll
+AS 'MODULE_PATHNAME'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION hll_send(hll)
+RETURNS bytea
+AS 'MODULE_PATHNAME'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE FUNCTION hll_typmod_in(cstring[])
 RETURNS integer
 AS 'MODULE_PATHNAME'
@@ -53,6 +63,8 @@ CREATE TYPE hll (
         OUTPUT = hll_out,
         TYPMOD_IN = hll_typmod_in,
         TYPMOD_OUT = hll_typmod_out,
+        RECEIVE = hll_recv,
+        SEND = hll_send,
         STORAGE = external
 );
 

--- a/hll.c
+++ b/hll.c
@@ -2266,13 +2266,12 @@ hll_type(PG_FUNCTION_ARGS)
     size_t asz;
     multiset_t	msa;
     uint8_t type;
-    uint8_t vers;
 
     ab = PG_GETARG_BYTEA_P(0);
     asz = VARSIZE(ab) - VARHDRSZ;
 
     // Unpack the multiset.
-    vers = multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, &type);
+    multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, &type);
 
 	PG_RETURN_INT32(type);
 }
@@ -2287,13 +2286,12 @@ hll_log2m(PG_FUNCTION_ARGS)
     bytea * ab;
     size_t asz;
     multiset_t	msa;
-    uint8_t vers;
 
     ab = PG_GETARG_BYTEA_P(0);
     asz = VARSIZE(ab) - VARHDRSZ;
 
     // Unpack the multiset.
-    vers = multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
+    multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
 
 	PG_RETURN_INT32(msa.ms_log2nregs);
 }
@@ -2308,13 +2306,12 @@ hll_regwidth(PG_FUNCTION_ARGS)
     bytea * ab;
     size_t asz;
     multiset_t	msa;
-    uint8_t vers;
 
     ab = PG_GETARG_BYTEA_P(0);
     asz = VARSIZE(ab) - VARHDRSZ;
 
     // Unpack the multiset.
-    vers = multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
+    multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
 
 	PG_RETURN_INT32(msa.ms_nbits);
 }
@@ -2329,7 +2326,6 @@ hll_expthresh(PG_FUNCTION_ARGS)
     bytea * ab;
     size_t asz;
     multiset_t	msa;
-    uint8_t vers;
 
     size_t nbits;
     size_t nregs;
@@ -2343,7 +2339,7 @@ hll_expthresh(PG_FUNCTION_ARGS)
     asz = VARSIZE(ab) - VARHDRSZ;
 
     // Unpack the multiset.
-    vers = multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
+    multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
 
     nbits = msa.ms_nbits;
     nregs = msa.ms_nregs;
@@ -2389,13 +2385,12 @@ hll_sparseon(PG_FUNCTION_ARGS)
     bytea * ab;
     size_t asz;
     multiset_t	msa;
-    uint8_t vers;
 
     ab = PG_GETARG_BYTEA_P(0);
     asz = VARSIZE(ab) - VARHDRSZ;
 
     // Unpack the multiset.
-    vers = multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
+    multiset_unpack(&msa, (uint8_t *) VARDATA(ab), asz, NULL);
 
 	PG_RETURN_INT32(msa.ms_sparseon);
 }

--- a/hll.c
+++ b/hll.c
@@ -33,6 +33,8 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "catalog/pg_type.h"
+#include "lib/stringinfo.h"
+#include "libpq/pqformat.h"
 
 #include "MurmurHash3.h"
 
@@ -3331,4 +3333,26 @@ hll_ceil_card_unpacked(PG_FUNCTION_ARGS)
         ceilval = (int64) ceil(retval);
         PG_RETURN_INT64(ceilval);
     }
+}
+
+PG_FUNCTION_INFO_V1(hll_recv);
+Datum hll_recv(PG_FUNCTION_ARGS);
+Datum
+hll_recv(PG_FUNCTION_ARGS)
+{
+    Datum dd = DirectFunctionCall1(bytearecv, PG_GETARG_DATUM(0));
+    return dd;
+}
+
+PG_FUNCTION_INFO_V1(hll_send);
+Datum hll_send(PG_FUNCTION_ARGS);
+Datum
+hll_send(PG_FUNCTION_ARGS)
+{
+    Datum dd = PG_GETARG_DATUM(0);
+    bytea* bp = DatumGetByteaP(dd);
+    StringInfoData buf;
+    pq_begintypsend(&buf);
+    pq_sendbytes(&buf, VARDATA(bp), VARSIZE(bp) - VARHDRSZ);
+    PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -64,6 +64,9 @@ OUT := $(SQL:%.sql=%.out)
 # Print NULL values explicitly.
 PSQLOPTS = --echo-all -P null=NULL
 
+# Disable NOTICE log messages
+export PGOPTIONS := --client-min-messages=warning
+
 all:	$(OUT)
 
 clean:

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -52,6 +52,7 @@ SQL =	\
 		cumulative_union_sparse_full_representation.sql \
 		cumulative_union_sparse_promotion.sql \
 		cumulative_union_sparse_sparse.sql \
+		copy_binary.sql \
 		$(NULL)
 
 TEST_DB = hll_regress
@@ -62,7 +63,7 @@ NOT =	\
 OUT := $(SQL:%.sql=%.out)
 
 # Print NULL values explicitly.
-PSQLOPTS = --echo-all -P null=NULL
+PSQLOPTS = -x --echo-all -P null=NULL
 
 # Disable NOTICE log messages
 export PGOPTIONS := --client-min-messages=warning

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -63,7 +63,7 @@ NOT =	\
 OUT := $(SQL:%.sql=%.out)
 
 # Print NULL values explicitly.
-PSQLOPTS = -x --echo-all -P null=NULL
+PSQLOPTS = -X --echo-all -P null=NULL
 
 # Disable NOTICE log messages
 export PGOPTIONS := --client-min-messages=warning

--- a/regress/add_agg.ref
+++ b/regress/add_agg.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_khvengxf;
-psql:add_agg.sql:7: NOTICE:  table "test_khvengxf" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_khvengxf (
 	val    integer

--- a/regress/agg_oob.ref
+++ b/regress/agg_oob.ref
@@ -10,13 +10,11 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_wdflbzfx;
-psql:agg_oob.sql:9: NOTICE:  table "test_wdflbzfx" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_wdflbzfx (
     recno    SERIAL,
     v1	     hll
 );
-psql:agg_oob.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_wdflbzfx_recno_seq" for serial column "test_wdflbzfx.recno"
 CREATE TABLE
 INSERT INTO test_wdflbzfx (recno, v1) VALUES
 -- NULL --

--- a/regress/copy_binary.ref
+++ b/regress/copy_binary.ref
@@ -1,0 +1,26 @@
+SELECT hll_set_output_version(1);
+-[ RECORD 1 ]----------+--
+hll_set_output_version | 1
+
+DROP TABLE IF EXISTS test_binary;
+DROP TABLE
+CREATE TABLE test_binary (id SERIAL, v1 hll);
+CREATE TABLE
+INSERT INTO test_binary(id,v1) VALUES (1, hll_empty() || hll_hash_text('A'));
+INSERT 0 1
+SELECT hll_cardinality(v1) FROM test_binary;
+-[ RECORD 1 ]---+--
+hll_cardinality | 1
+
+\COPY test_binary TO 'binary.dat' WITH (FORMAT binary)
+DELETE FROM test_binary;
+DELETE 1
+SELECT hll_cardinality(v1) FROM test_binary;
+(No rows)
+\COPY test_binary FROM 'binary.dat' WITH (FORMAT binary)
+SELECT hll_cardinality(v1) FROM test_binary;
+-[ RECORD 1 ]---+--
+hll_cardinality | 1
+
+DROP TABLE test_binary;
+DROP TABLE

--- a/regress/copy_binary.ref
+++ b/regress/copy_binary.ref
@@ -1,6 +1,8 @@
 SELECT hll_set_output_version(1);
--[ RECORD 1 ]----------+--
-hll_set_output_version | 1
+ hll_set_output_version 
+------------------------
+                      1
+(1 row)
 
 DROP TABLE IF EXISTS test_binary;
 DROP TABLE
@@ -9,18 +11,25 @@ CREATE TABLE
 INSERT INTO test_binary(id,v1) VALUES (1, hll_empty() || hll_hash_text('A'));
 INSERT 0 1
 SELECT hll_cardinality(v1) FROM test_binary;
--[ RECORD 1 ]---+--
-hll_cardinality | 1
+ hll_cardinality 
+-----------------
+               1
+(1 row)
 
 \COPY test_binary TO 'binary.dat' WITH (FORMAT binary)
 DELETE FROM test_binary;
 DELETE 1
 SELECT hll_cardinality(v1) FROM test_binary;
-(No rows)
+ hll_cardinality 
+-----------------
+(0 rows)
+
 \COPY test_binary FROM 'binary.dat' WITH (FORMAT binary)
 SELECT hll_cardinality(v1) FROM test_binary;
--[ RECORD 1 ]---+--
-hll_cardinality | 1
+ hll_cardinality 
+-----------------
+               1
+(1 row)
 
 DROP TABLE test_binary;
 DROP TABLE

--- a/regress/copy_binary.sql
+++ b/regress/copy_binary.sql
@@ -1,0 +1,21 @@
+SELECT hll_set_output_version(1);
+
+DROP TABLE IF EXISTS test_binary;
+
+CREATE TABLE test_binary (id SERIAL, v1 hll);
+
+INSERT INTO test_binary(id,v1) VALUES (1, hll_empty() || hll_hash_text('A'));
+
+SELECT hll_cardinality(v1) FROM test_binary;
+
+\COPY test_binary TO 'binary.dat' WITH (FORMAT binary)
+
+DELETE FROM test_binary;
+
+SELECT hll_cardinality(v1) FROM test_binary;
+
+\COPY test_binary FROM 'binary.dat' WITH (FORMAT binary)
+
+SELECT hll_cardinality(v1) FROM test_binary;
+
+DROP TABLE test_binary;

--- a/regress/cumulative_add_cardinality_correction.ref
+++ b/regress/cumulative_add_cardinality_correction.ref
@@ -17,7 +17,6 @@ SELECT hll_set_max_sparse(0);
 (1 row)
 
 DROP TABLE IF EXISTS test_msgfjqhm;
-psql:cumulative_add_cardinality_correction.sql:12: NOTICE:  table "test_msgfjqhm" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_msgfjqhm (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_msgfjqhm (
     raw_value                   bigint,
     union_compressed_multiset   hll
 );
-psql:cumulative_add_cardinality_correction.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_msgfjqhm_recno_seq" for serial column "test_msgfjqhm.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_add_comprehensive_promotion.ref
+++ b/regress/cumulative_add_comprehensive_promotion.ref
@@ -17,7 +17,6 @@ SELECT hll_set_max_sparse(512);
 (1 row)
 
 DROP TABLE IF EXISTS test_ptwysrqk;
-psql:cumulative_add_comprehensive_promotion.sql:12: NOTICE:  table "test_ptwysrqk" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_ptwysrqk (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_ptwysrqk (
     raw_value                   bigint,
     union_compressed_multiset   hll
 );
-psql:cumulative_add_comprehensive_promotion.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_ptwysrqk_recno_seq" for serial column "test_ptwysrqk.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_add_sparse_edge.ref
+++ b/regress/cumulative_add_sparse_edge.ref
@@ -17,7 +17,6 @@ SELECT hll_set_max_sparse(512);
 (1 row)
 
 DROP TABLE IF EXISTS test_eopzdzwz;
-psql:cumulative_add_sparse_edge.sql:12: NOTICE:  table "test_eopzdzwz" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_eopzdzwz (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_eopzdzwz (
     raw_value                   bigint,
     union_compressed_multiset   hll
 );
-psql:cumulative_add_sparse_edge.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_eopzdzwz_recno_seq" for serial column "test_eopzdzwz.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_add_sparse_random.ref
+++ b/regress/cumulative_add_sparse_random.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_beelewuo;
-psql:cumulative_add_sparse_random.sql:7: NOTICE:  table "test_beelewuo" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_beelewuo (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_beelewuo (
     raw_value                   bigint,
     union_compressed_multiset   hll
 );
-psql:cumulative_add_sparse_random.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_beelewuo_recno_seq" for serial column "test_beelewuo.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_add_sparse_step.ref
+++ b/regress/cumulative_add_sparse_step.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_lunfjncl;
-psql:cumulative_add_sparse_step.sql:7: NOTICE:  table "test_lunfjncl" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_lunfjncl (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_lunfjncl (
     raw_value                   bigint,
     union_compressed_multiset   hll
 );
-psql:cumulative_add_sparse_step.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_lunfjncl_recno_seq" for serial column "test_lunfjncl.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_comprehensive.ref
+++ b/regress/cumulative_union_comprehensive.ref
@@ -7,7 +7,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_rhswkjtc;
-psql:cumulative_union_comprehensive.sql:6: NOTICE:  table "test_rhswkjtc" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_rhswkjtc (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_rhswkjtc (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_comprehensive.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_rhswkjtc_recno_seq" for serial column "test_rhswkjtc.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_explicit_explicit.ref
+++ b/regress/cumulative_union_explicit_explicit.ref
@@ -7,7 +7,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_swlnhisq;
-psql:cumulative_union_explicit_explicit.sql:6: NOTICE:  table "test_swlnhisq" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_swlnhisq (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_swlnhisq (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_explicit_explicit.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_swlnhisq_recno_seq" for serial column "test_swlnhisq.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_explicit_promotion.ref
+++ b/regress/cumulative_union_explicit_promotion.ref
@@ -16,7 +16,6 @@ SELECT hll_set_max_sparse(512);
 (1 row)
 
 DROP TABLE IF EXISTS test_wsdiietv;
-psql:cumulative_union_explicit_promotion.sql:11: NOTICE:  table "test_wsdiietv" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_wsdiietv (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_wsdiietv (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_explicit_promotion.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_wsdiietv_recno_seq" for serial column "test_wsdiietv.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_probabilistic_probabilistic.ref
+++ b/regress/cumulative_union_probabilistic_probabilistic.ref
@@ -7,7 +7,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_mpuahgwy;
-psql:cumulative_union_probabilistic_probabilistic.sql:6: NOTICE:  table "test_mpuahgwy" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_mpuahgwy (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_mpuahgwy (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_probabilistic_probabilistic.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_mpuahgwy_recno_seq" for serial column "test_mpuahgwy.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_sparse_full_representation.ref
+++ b/regress/cumulative_union_sparse_full_representation.ref
@@ -16,7 +16,6 @@ SELECT hll_set_max_sparse(512);
 (1 row)
 
 DROP TABLE IF EXISTS test_tagumlbl;
-psql:cumulative_union_sparse_full_representation.sql:11: NOTICE:  table "test_tagumlbl" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_tagumlbl (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_tagumlbl (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_sparse_full_representation.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_tagumlbl_recno_seq" for serial column "test_tagumlbl.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_sparse_promotion.ref
+++ b/regress/cumulative_union_sparse_promotion.ref
@@ -16,7 +16,6 @@ SELECT hll_set_max_sparse(512);
 (1 row)
 
 DROP TABLE IF EXISTS test_bsnvqefe;
-psql:cumulative_union_sparse_promotion.sql:11: NOTICE:  table "test_bsnvqefe" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_bsnvqefe (
     recno                       SERIAL,
@@ -25,7 +24,6 @@ CREATE TABLE test_bsnvqefe (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_sparse_promotion.sql:19: NOTICE:  CREATE TABLE will create implicit sequence "test_bsnvqefe_recno_seq" for serial column "test_bsnvqefe.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/cumulative_union_sparse_sparse.ref
+++ b/regress/cumulative_union_sparse_sparse.ref
@@ -7,7 +7,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_bmbffonl;
-psql:cumulative_union_sparse_sparse.sql:6: NOTICE:  table "test_bmbffonl" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_bmbffonl (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_bmbffonl (
     union_cardinality           double precision,
     union_compressed_multiset   hll
 );
-psql:cumulative_union_sparse_sparse.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_bmbffonl_recno_seq" for serial column "test_bmbffonl.recno"
 CREATE TABLE
 -- Copy the CSV data into the table
 --

--- a/regress/murmur_bigint.ref
+++ b/regress/murmur_bigint.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_seznjqbb;
-psql:murmur_bigint.sql:7: NOTICE:  table "test_seznjqbb" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_seznjqbb (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_seznjqbb (
     pre_hash_long               bigint,
     post_hash_long              bigint
 );
-psql:murmur_bigint.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_seznjqbb_recno_seq" for serial column "test_seznjqbb.recno"
 CREATE TABLE
 \copy test_seznjqbb (seed, pre_hash_long, post_hash_long) from pstdin with csv header
 SELECT COUNT(*) FROM test_seznjqbb;

--- a/regress/murmur_bytea.ref
+++ b/regress/murmur_bytea.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_qfwzdmoy;
-psql:murmur_bytea.sql:7: NOTICE:  table "test_qfwzdmoy" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_qfwzdmoy (
     recno                       SERIAL,
@@ -16,7 +15,6 @@ CREATE TABLE test_qfwzdmoy (
     pre_hash_long               bytea,
     post_hash_long              bigint
 );
-psql:murmur_bytea.sql:14: NOTICE:  CREATE TABLE will create implicit sequence "test_qfwzdmoy_recno_seq" for serial column "test_qfwzdmoy.recno"
 CREATE TABLE
 \copy test_qfwzdmoy (seed, pre_hash_long, post_hash_long) from pstdin with csv header
 SELECT COUNT(*) FROM test_qfwzdmoy;

--- a/regress/typmod.ref
+++ b/regress/typmod.ref
@@ -8,7 +8,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_qiundgkm;
-psql:typmod.sql:7: NOTICE:  table "test_qiundgkm" does not exist, skipping
 DROP TABLE
 -- Using all defaults.
 CREATE TABLE test_qiundgkm (v1 hll);

--- a/regress/typmod_insert.ref
+++ b/regress/typmod_insert.ref
@@ -5,7 +5,6 @@ SELECT hll_set_output_version(1);
 (1 row)
 
 DROP TABLE IF EXISTS test_trsybeqs;
-psql:typmod_insert.sql:3: NOTICE:  table "test_trsybeqs" does not exist, skipping
 DROP TABLE
 CREATE TABLE test_trsybeqs (
     val   hll(10)


### PR DESCRIPTION
Binary input/output for HLL type. Helps to make bulk loads faster.

Fix GCC 4.8 compiler warnings.

hll.c:2269:13: warning: variable ‘vers’ set but not used [-Wunused-but-set-variable]
hll.c:2290:13: warning: variable ‘vers’ set but not used [-Wunused-but-set-variable]
hll.c:2311:13: warning: variable ‘vers’ set but not used [-Wunused-but-set-variable]
hll.c:2332:13: warning: variable ‘vers’ set but not used [-Wunused-but-set-variable]
hll.c:2392:13: warning: variable ‘vers’ set but not used [-Wunused-but-set-variable]
MurmurHash3.cpp:86:23: warning: always_inline function might not be inlinable [-Wattributes]
MurmurHash3.cpp:73:23: warning: always_inline function might not be inlinable [-Wattributes]
MurmurHash3.cpp:65:23: warning: always_inline function might not be inlinable [-Wattributes]
MurmurHash3.cpp:60:23: warning: always_inline function might not be inlinable [-Wattributes]

Remove NOTICE logs from tests because they don't seem to be consistent across different versions of Postgres.
