### PR TITLE
Ignore supplimentary output for 9.4 during regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.o
 *.so
 *.out
+*.diff
+regress/binary.dat
+regress/failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+
+env:
+  - PGVERSION=9.1
+  - PGVERSION=9.2
+  - PGVERSION=9.3
+
+before_script:
+  - export PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH     # Add our chosen PG version to the path
+  - sudo /etc/init.d/postgresql stop                         # Stop whichever version of PG that travis started
+  - sudo /etc/init.d/postgresql start $PGVERSION             # Start the version of PG that we want to test
+  - sudo apt-get install postgresql-server-dev-$PGVERSION    # Required for PGXS
+  - sudo apt-get install postgresql-common                   # Required for extension support files
+  - createdb hll_regress                                     # Create the test database
+
+script:
+  - make && sudo make install
+  - psql -c "create extension hll" hll_regress
+  - make -C regress
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - PGVERSION=9.1
   - PGVERSION=9.2
   - PGVERSION=9.3
+  - PGVERSION=9.4
 
 before_script:
   - export PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH     # Add our chosen PG version to the path

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/aggregateknowledge/postgresql-hll.svg?branch=master)](https://travis-ci.org/aggregateknowledge/postgresql-hll)
+
 Overview
 ========
 

--- a/README.markdown
+++ b/README.markdown
@@ -361,7 +361,7 @@ Compatibility
 
 This module has been tested on:
 
-* **Postgres 9.0, 9.1, 9.2, 9.3**
+* **Postgres 9.0, 9.1, 9.2, 9.3, 9.4**
 
 If you end up needing to change something to get this running on another system, send us the diff and we'll try to work it in!
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -19,69 +19,45 @@
 # ../testdata/foo.csv	- (optional data file for \copy from pstdin)
 # foo.out				- actual output
 
-SQL =	\
-		add_agg.sql \
-		auto_sparse.sql \
-		explicit_thresh.sql \
-		nosparse.sql \
-		agg_oob.sql \
-		cast_shape.sql \
-		scalar_oob.sql \
-		typmod.sql \
-		typmod_insert.sql \
-		hash.sql \
-		hash_any.sql \
-		murmur_bigint.sql \
-		murmur_bytea.sql \
-		equal.sql \
-		notequal.sql \
-		union_op.sql\
-		card_op.sql \
-		meta_func.sql \
-		transaction.sql \
-		storedproc.sql \
-		cumulative_add_cardinality_correction.sql \
-		cumulative_add_comprehensive_promotion.sql \
-		cumulative_add_sparse_edge.sql \
-		cumulative_add_sparse_random.sql \
-		cumulative_add_sparse_step.sql \
-		cumulative_union_comprehensive.sql \
-		cumulative_union_explicit_explicit.sql \
-		cumulative_union_explicit_promotion.sql \
-		cumulative_union_probabilistic_probabilistic.sql \
-		cumulative_union_sparse_full_representation.sql \
-		cumulative_union_sparse_promotion.sql \
-		cumulative_union_sparse_sparse.sql \
-		copy_binary.sql \
-		$(NULL)
+PSQL      = psql
+TEST_DB   = hll_regress
 
-TEST_DB = hll_regress
+SQL       = $(wildcard *.sql)
+OUT      := $(SQL:%.sql=%.out)
 
-NOT =	\
-		$(NULL)
-
-OUT := $(SQL:%.sql=%.out)
-
-# Print NULL values explicitly.
-PSQLOPTS = -X --echo-all -P null=NULL
-
-# Disable NOTICE log messages
-export PGOPTIONS := --client-min-messages=warning
+PSQLOPTS  = -X --echo-all -P null=NULL       # Print NULL values explicitly.
+PGOPTIONS = --client-min-messages=warning    # Output WARNINGS
 
 all:	$(OUT)
+	@find . -maxdepth 1 -name '*.diff' -print -quit > failures
+	@if test -s failures; then \
+		echo ERROR: `ls -1 *.diff | wc -l` / `ls -1 *.sql | wc -l` tests failed; \
+		echo; \
+		cat *.diff; \
+		exit 1; \
+	else \
+		rm failures; \
+		echo `ls -1 *.out | wc -l` / `ls -1 *.sql | wc -l` tests passed; \
+	fi
 
 clean:
-	rm -f $(OUT)
-	rm -f binary.dat
+	rm -f binary.dat *.out *.diff
 
 # If a matching testdata file exists use it as standard input.
 # Otherwise the test doesn't need data on stdin.
 #
 %.out:	%.sql %.ref
-	@echo $*
+	@echo -n $*
 	@if test -f ../testdata/$*.csv; then \
-	  cat ../testdata/$*.csv | \
-	  psql $(PSQLOPTS) $(TEST_DB) -f $*.sql &> $*.out && diff -u $*.ref $*.out; \
+	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql < ../testdata/$*.csv > $*.out 2>&1; \
 	else \
-	  psql $(PSQLOPTS) $(TEST_DB) -f $*.sql &> $*.out && diff -u $*.ref $*.out; \
-    fi
+	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql > $*.out 2>&1; \
+	fi
+	@diff -u $*.ref $*.out >> $*.diff || status=1
+	@if test -s $*.diff; then \
+		echo " .. FAIL"; \
+	else \
+		echo " .. PASS"; \
+		rm -f $*.diff; \
+	fi
+

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -53,7 +53,8 @@ clean:
 	else \
 	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql > $*.out 2>&1; \
 	fi
-	@diff -u $*.ref $*.out >> $*.diff || status=1
+	# We ignore some additional output from PG 9.4 and newer.
+	@diff -u -I "^COPY.*" $*.ref $*.out >> $*.diff || status=1
 	@if test -s $*.diff; then \
 		echo " .. FAIL"; \
 	else \


### PR DESCRIPTION
This is a potential fix for https://github.com/aggregateknowledge/postgresql-hll/issues/25.

It's such a minor change, I don't know that it warrants a version bump. If anybody should think it warranted, I'd be happy to update that as well.

Cheers,
-Gavin
