### PR TITLE
add explicit cast to signed value (multiplication of uint64_t with -1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.o
 *.so
 *.out
+*.diff
+regress/binary.dat
+regress/failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+
+env:
+  - PGVERSION=9.1
+  - PGVERSION=9.2
+  - PGVERSION=9.3
+
+before_script:
+  - export PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH     # Add our chosen PG version to the path
+  - sudo /etc/init.d/postgresql stop                         # Stop whichever version of PG that travis started
+  - sudo /etc/init.d/postgresql start $PGVERSION             # Start the version of PG that we want to test
+  - sudo apt-get install postgresql-server-dev-$PGVERSION    # Required for PGXS
+  - sudo apt-get install postgresql-common                   # Required for extension support files
+  - createdb hll_regress                                     # Create the test database
+
+script:
+  - make && sudo make install
+  - psql -c "create extension hll" hll_regress
+  - make -C regress
+

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/aggregateknowledge/postgresql-hll.svg?branch=master)](https://travis-ci.org/aggregateknowledge/postgresql-hll)
+
 Overview
 ========
 

--- a/hll.c
+++ b/hll.c
@@ -1967,7 +1967,7 @@ multiset_card(multiset_t const * i_msp)
             else if (estimator <= large_estimator_cutoff)
                 retval = estimator;
             else
-                return (-1 * two_to_l) * log(1.0 - (estimator/two_to_l));
+                return (-1 * (int64_t)two_to_l) * log(1.0 - (estimator/two_to_l));
         }
         break;
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -19,69 +19,45 @@
 # ../testdata/foo.csv	- (optional data file for \copy from pstdin)
 # foo.out				- actual output
 
-SQL =	\
-		add_agg.sql \
-		auto_sparse.sql \
-		explicit_thresh.sql \
-		nosparse.sql \
-		agg_oob.sql \
-		cast_shape.sql \
-		scalar_oob.sql \
-		typmod.sql \
-		typmod_insert.sql \
-		hash.sql \
-		hash_any.sql \
-		murmur_bigint.sql \
-		murmur_bytea.sql \
-		equal.sql \
-		notequal.sql \
-		union_op.sql\
-		card_op.sql \
-		meta_func.sql \
-		transaction.sql \
-		storedproc.sql \
-		cumulative_add_cardinality_correction.sql \
-		cumulative_add_comprehensive_promotion.sql \
-		cumulative_add_sparse_edge.sql \
-		cumulative_add_sparse_random.sql \
-		cumulative_add_sparse_step.sql \
-		cumulative_union_comprehensive.sql \
-		cumulative_union_explicit_explicit.sql \
-		cumulative_union_explicit_promotion.sql \
-		cumulative_union_probabilistic_probabilistic.sql \
-		cumulative_union_sparse_full_representation.sql \
-		cumulative_union_sparse_promotion.sql \
-		cumulative_union_sparse_sparse.sql \
-		copy_binary.sql \
-		$(NULL)
+PSQL      = psql
+TEST_DB   = hll_regress
 
-TEST_DB = hll_regress
+SQL       = $(wildcard *.sql)
+OUT      := $(SQL:%.sql=%.out)
 
-NOT =	\
-		$(NULL)
-
-OUT := $(SQL:%.sql=%.out)
-
-# Print NULL values explicitly.
-PSQLOPTS = -X --echo-all -P null=NULL
-
-# Disable NOTICE log messages
-export PGOPTIONS := --client-min-messages=warning
+PSQLOPTS  = -X --echo-all -P null=NULL       # Print NULL values explicitly.
+PGOPTIONS = --client-min-messages=warning    # Output WARNINGS
 
 all:	$(OUT)
+	@find . -maxdepth 1 -name '*.diff' -print -quit > failures
+	@if test -s failures; then \
+		echo ERROR: `ls -1 *.diff | wc -l` / `ls -1 *.sql | wc -l` tests failed; \
+		echo; \
+		cat *.diff; \
+		exit 1; \
+	else \
+		rm failures; \
+		echo `ls -1 *.out | wc -l` / `ls -1 *.sql | wc -l` tests passed; \
+	fi
 
 clean:
-	rm -f $(OUT)
-	rm -f binary.dat
+	rm -f binary.dat *.out *.diff
 
 # If a matching testdata file exists use it as standard input.
 # Otherwise the test doesn't need data on stdin.
 #
 %.out:	%.sql %.ref
-	@echo $*
+	@echo -n $*
 	@if test -f ../testdata/$*.csv; then \
-	  cat ../testdata/$*.csv | \
-	  psql $(PSQLOPTS) $(TEST_DB) -f $*.sql &> $*.out && diff -u $*.ref $*.out; \
+	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql < ../testdata/$*.csv > $*.out 2>&1; \
 	else \
-	  psql $(PSQLOPTS) $(TEST_DB) -f $*.sql &> $*.out && diff -u $*.ref $*.out; \
-    fi
+	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql > $*.out 2>&1; \
+	fi
+	@diff -u $*.ref $*.out >> $*.diff || status=1
+	@if test -s $*.diff; then \
+		echo " .. FAIL"; \
+	else \
+		echo " .. PASS"; \
+		rm -f $*.diff; \
+	fi
+


### PR DESCRIPTION
For some inputs hll_cardinality function returns negative results. It is caused by invalid multiplication of uint64_t with -1. 

Example: 

select public.hll_cardinality( decode( '14887fc63f9d735adef38d7779ce7dace3bcd67b9ee319df73fdf339d777dee75ae6bbbc6759deb3bdeb5ace7bcc673bce718debbbceb5bd775bc6bfdd6f39eeb39debbec671ce6b9ec735acf35ad735acf3bbd6b99d637bfeb7aeef99d6739d7fbacef5ad7399e7738d6f5ed6f9bc6b5bceb3edeb7bdef5ac67d8e6f7bdef3afe759cff59ef39ac6f9ecef59c6b5ac6f3cc63bee6f39d6b3ae677cd677cd6b58ef3fa', 'hex')::hll ) ; 

result before fix:  -7.01470685321371e+17
result after fix: 10452727910.4903
