### PR TITLE
Update Travis to build on latest PostgreSQL versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+sudo: required
+dist: trusty
 language: c
-
 env:
   - PGVERSION=9.1
   - PGVERSION=9.2
   - PGVERSION=9.3
   - PGVERSION=9.4
-
+  - PGVERSION=9.5
 before_script:
   - export PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH     # Add our chosen PG version to the path
   - sudo /etc/init.d/postgresql stop                         # Stop whichever version of PG that travis started
@@ -14,7 +15,6 @@ before_script:
   - sudo apt-get install postgresql-server-dev-$PGVERSION    # Required for PGXS
   - sudo apt-get install postgresql-common                   # Required for extension support files
   - createdb hll_regress                                     # Create the test database
-
 script:
   - make && sudo make install
   - psql -c "create extension hll" hll_regress

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ env:
   - PGVERSION=9.1
   - PGVERSION=9.2
   - PGVERSION=9.3
+  - PGVERSION=9.4
 
 before_script:
   - export PATH=/usr/lib/postgresql/$PGVERSION/bin:$PATH     # Add our chosen PG version to the path
   - sudo /etc/init.d/postgresql stop                         # Stop whichever version of PG that travis started
   - sudo /etc/init.d/postgresql start $PGVERSION             # Start the version of PG that we want to test
+  - sudo apt-get update -qq                                  # Retrieves new list of packages
   - sudo apt-get install postgresql-server-dev-$PGVERSION    # Required for PGXS
   - sudo apt-get install postgresql-common                   # Required for extension support files
   - createdb hll_regress                                     # Create the test database
@@ -17,4 +19,3 @@ script:
   - make && sudo make install
   - psql -c "create extension hll" hll_regress
   - make -C regress
-

--- a/README.markdown
+++ b/README.markdown
@@ -361,7 +361,7 @@ Compatibility
 
 This module has been tested on:
 
-* **Postgres 9.0, 9.1, 9.2, 9.3**
+* **Postgres 9.0, 9.1, 9.2, 9.3, 9.4**
 
 If you end up needing to change something to get this running on another system, send us the diff and we'll try to work it in!
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -53,7 +53,7 @@ clean:
 	else \
 	  PGOPTIONS=$(PGOPTIONS) $(PSQL) $(PSQLOPTS) $(TEST_DB) -f $*.sql > $*.out 2>&1; \
 	fi
-	@diff -u $*.ref $*.out >> $*.diff || status=1
+	@diff -u -I "^COPY.*" $*.ref $*.out >> $*.diff || status=1
 	@if test -s $*.diff; then \
 		echo " .. FAIL"; \
 	else \


### PR DESCRIPTION
Uses commits from aggregateknowledge/postgresql-hll#26 to get this
running on 9.4, as well as a minor Travis change to build on 9.5. As
I'm still having trouble getting the tests to pass on my OS X box,
I'll use Travis for testing, as things seem to be OK there.