### PR TITLE
Tell size of the internal state object to PostgreSQL

### DIFF
--- a/hll--2.10.sql
+++ b/hll--2.10.sql
@@ -465,6 +465,7 @@ CREATE FUNCTION hll_ceil_card_unpacked(internal)
 CREATE AGGREGATE hll_union_agg (hll) (
        SFUNC = hll_union_trans,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );
 
@@ -475,6 +476,7 @@ CREATE AGGREGATE hll_union_agg (hll) (
 CREATE AGGREGATE hll_add_agg (hll_hashval) (
        SFUNC = hll_add_trans0,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );
 
@@ -482,6 +484,7 @@ CREATE AGGREGATE hll_add_agg (hll_hashval) (
 CREATE AGGREGATE hll_add_agg (hll_hashval, integer) (
        SFUNC = hll_add_trans1,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );
 
@@ -489,6 +492,7 @@ CREATE AGGREGATE hll_add_agg (hll_hashval, integer) (
 CREATE AGGREGATE hll_add_agg (hll_hashval, integer, integer) (
        SFUNC = hll_add_trans2,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );
 
@@ -496,6 +500,7 @@ CREATE AGGREGATE hll_add_agg (hll_hashval, integer, integer) (
 CREATE AGGREGATE hll_add_agg (hll_hashval, integer, integer, bigint) (
        SFUNC = hll_add_trans3,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );
 
@@ -503,5 +508,6 @@ CREATE AGGREGATE hll_add_agg (hll_hashval, integer, integer, bigint) (
 CREATE AGGREGATE hll_add_agg (hll_hashval, integer, integer, bigint, integer) (
        SFUNC = hll_add_trans4,
        STYPE = internal,
+       SSPACE = 131113,
        FINALFUNC = hll_pack
 );


### PR DESCRIPTION
When this value is not specified, PostgreSQL planner estimates the memory
need lesser than actual need and thinks it is OK to use Hash Aggreage.
Since actual memory need is higher, available memory may not enough to use
Hash Aggregate. This causes out of memory issues and/or crashes.