### PR TITLE
palloc multiset_t in explicit_to_compressed

### DIFF
--- a/src/hll.c
+++ b/src/hll.c
@@ -622,20 +622,22 @@ static void
 explicit_to_compressed(multiset_t * msp)
 {
     // Make a copy of the explicit multiset.
-    multiset_t ms;
-    memcpy(&ms, msp, sizeof(ms));
+    multiset_t *tmp = palloc(sizeof *msp);
+    memcpy(tmp, msp, sizeof *tmp);
 
     // Clear the multiset.
     memset(msp, '\0', sizeof(*msp));
 
     // Restore the metadata.
-    copy_metadata(msp, &ms);
+    copy_metadata(msp, tmp);
 
     // Make it MST_COMPRESSED.
     msp->ms_type = MST_COMPRESSED;
 
     // Add all the elements back into the compressed multiset.
-    compressed_explicit_union(msp, &ms);
+    compressed_explicit_union(msp, tmp);
+
+    pfree(tmp);
 }
 
 static int


### PR DESCRIPTION
On one installation that operates in low-memory conditions, we have
repeated segmentation faults on the stack in `explicit_to_compressed`.
What's important about this function is that it has the 130KB
`multiset_t` struct allocated on the stack.

There is a documented gap in Linux's overcommit-off mode, whereby
C-stack growth is automatic and can fail by failing to extend the
stack map:
https://www.kernel.org/doc/Documentation/vm/overcommit-accounting

To test this theory, use palloc in this one case: since palloc is not
an implied allocation of memory, it'll fail per normal and begin
transaction rollback.

If it prevents segmentation fault, then we might have to think about
how to not put such a large struct on the stack elsewhere.  Having
made an attempt to do this throughout, it's somewhat invasive and
opens room for memory-reuse errors, so let's confirm the theory with a
small patch first.