### PR TITLE
Fix out of range

### DIFF
--- a/expected/add_agg.out
+++ b/expected/add_agg.out
@@ -77,10 +77,10 @@ select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 512, 0))
 -- Check range checking.
 select hll_print(hll_add_agg(hll_hash_integer(val), -1))
        from test_khvengxf;
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 select hll_print(hll_add_agg(hll_hash_integer(val), 32))
        from test_khvengxf;
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, -1))
        from test_khvengxf;
 ERROR:  regwidth modifier must be between 0 and 7
@@ -89,10 +89,10 @@ select hll_print(hll_add_agg(hll_hash_integer(val), 10, 8))
 ERROR:  regwidth modifier must be between 0 and 7
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, -2))
        from test_khvengxf;
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 8589934592))
        from test_khvengxf;
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 select hll_print(hll_add_agg(hll_hash_integer(val), 10, 4, 512, -1))
        from test_khvengxf;
 ERROR:  sparseon modifier must be 0 or 1

--- a/expected/typmod.out
+++ b/expected/typmod.out
@@ -59,9 +59,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(10, 4, 64, 0, 42));
 -- ----------------------------------------------------------------
 -- Range Check log2nregs
 -- ----------------------------------------------------------------
--- ERROR:  log2m modifier must be between 0 and 31
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(-1));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(-1));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(0));
@@ -73,16 +73,15 @@ CREATE TABLE test_qiundgkm (v1 hll(0));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(31));
+ERROR:  log2m modifier must be between 0 and 17
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(31));
+                                       ^
 \d test_qiundgkm
-               Table "public.test_qiundgkm"
- Column |      Type      | Collation | Nullable | Default 
---------+----------------+-----------+----------+---------
- v1     | hll(31,5,-1,1) |           |          | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  log2m modifier must be between 0 and 31
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(32));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(32));
                                        ^
 -- ----------------------------------------------------------------
@@ -117,9 +116,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 8));
 -- ----------------------------------------------------------------
 -- Range Check expthresh
 -- ----------------------------------------------------------------
--- ERROR:  expthresh modifier must be between -1 and 2^32
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -1));
@@ -147,16 +146,15 @@ CREATE TABLE test_qiundgkm (v1 hll(11, 5, 128));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+ERROR:  expthresh modifier must be between -1 and 16383
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+                                       ^
 \d test_qiundgkm
-                   Table "public.test_qiundgkm"
- Column |          Type          | Collation | Nullable | Default 
---------+------------------------+-----------+----------+---------
- v1     | hll(11,5,4294967296,1) |           |          | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
                                        ^
 -- ----------------------------------------------------------------

--- a/expected/typmod_0.out
+++ b/expected/typmod_0.out
@@ -59,9 +59,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(10, 4, 64, 0, 42));
 -- ----------------------------------------------------------------
 -- Range Check log2nregs
 -- ----------------------------------------------------------------
--- ERROR:  log2m modifier must be between 0 and 31
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(-1));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(-1));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(0));
@@ -73,16 +73,15 @@ CREATE TABLE test_qiundgkm (v1 hll(0));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(31));
+ERROR:  log2m modifier must be between 0 and 17
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(31));
+                                       ^
 \d test_qiundgkm
-    Table "public.test_qiundgkm"
- Column |      Type      | Collation | Nullable | Default 
---------+----------------+-----------+----------+---------
- v1     | hll(31,5,-1,1) |           |          | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  log2m modifier must be between 0 and 31
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(32));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(32));
                                        ^
 -- ----------------------------------------------------------------
@@ -117,9 +116,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 8));
 -- ----------------------------------------------------------------
 -- Range Check expthresh
 -- ----------------------------------------------------------------
--- ERROR:  expthresh modifier must be between -1 and 2^32
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -1));
@@ -147,16 +146,15 @@ CREATE TABLE test_qiundgkm (v1 hll(11, 5, 128));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+ERROR:  expthresh modifier must be between -1 and 16383
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+                                       ^
 \d test_qiundgkm
-        Table "public.test_qiundgkm"
- Column |          Type          | Collation | Nullable | Default 
---------+------------------------+-----------+----------+---------
- v1     | hll(11,5,4294967296,1) |           |          | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
                                        ^
 -- ----------------------------------------------------------------

--- a/expected/typmod_1.out
+++ b/expected/typmod_1.out
@@ -59,9 +59,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(10, 4, 64, 0, 42));
 -- ----------------------------------------------------------------
 -- Range Check log2nregs
 -- ----------------------------------------------------------------
--- ERROR:  log2m modifier must be between 0 and 31
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(-1));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(-1));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(0));
@@ -73,16 +73,15 @@ CREATE TABLE test_qiundgkm (v1 hll(0));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(31));
+ERROR:  log2m modifier must be between 0 and 17
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(31));
+                                       ^
 \d test_qiundgkm
-    Table "public.test_qiundgkm"
- Column |      Type      | Modifiers 
---------+----------------+-----------
- v1     | hll(31,5,-1,1) | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  log2m modifier must be between 0 and 31
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(32));
-ERROR:  log2m modifier must be between 0 and 31
+ERROR:  log2m modifier must be between 0 and 17
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(32));
                                        ^
 -- ----------------------------------------------------------------
@@ -117,9 +116,9 @@ LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 8));
 -- ----------------------------------------------------------------
 -- Range Check expthresh
 -- ----------------------------------------------------------------
--- ERROR:  expthresh modifier must be between -1 and 2^32
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
                                        ^
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -1));
@@ -147,16 +146,15 @@ CREATE TABLE test_qiundgkm (v1 hll(11, 5, 128));
 
 DROP TABLE test_qiundgkm;
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+ERROR:  expthresh modifier must be between -1 and 16383
+LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
+                                       ^
 \d test_qiundgkm
-        Table "public.test_qiundgkm"
- Column |          Type          | Modifiers 
---------+------------------------+-----------
- v1     | hll(11,5,4294967296,1) | 
-
 DROP TABLE test_qiundgkm;
--- ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  table "test_qiundgkm" does not exist
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
-ERROR:  expthresh modifier must be between -1 and 2^32
+ERROR:  expthresh modifier must be between -1 and 16383
 LINE 1: CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
                                        ^
 -- ----------------------------------------------------------------

--- a/sql/typmod.sql
+++ b/sql/typmod.sql
@@ -35,7 +35,7 @@ CREATE TABLE test_qiundgkm (v1 hll(10, 4, 64, 0, 42));
 -- Range Check log2nregs
 -- ----------------------------------------------------------------
 
--- ERROR:  log2m modifier must be between 0 and 31
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(-1));
 
 CREATE TABLE test_qiundgkm (v1 hll(0));
@@ -46,7 +46,7 @@ CREATE TABLE test_qiundgkm (v1 hll(31));
 \d test_qiundgkm
 DROP TABLE test_qiundgkm;
 
--- ERROR:  log2m modifier must be between 0 and 31
+-- ERROR:  log2m modifier must be between 0 and 17
 CREATE TABLE test_qiundgkm (v1 hll(32));
 
 -- ----------------------------------------------------------------
@@ -71,7 +71,7 @@ CREATE TABLE test_qiundgkm (v1 hll(11, 8));
 -- Range Check expthresh
 -- ----------------------------------------------------------------
 
--- ERROR:  expthresh modifier must be between -1 and 2^32
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -2));
 
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, -1));
@@ -90,7 +90,7 @@ CREATE TABLE test_qiundgkm (v1 hll(11, 5, 4294967296));
 \d test_qiundgkm
 DROP TABLE test_qiundgkm;
 
--- ERROR:  expthresh modifier must be between -1 and 2^32
+-- ERROR:  expthresh modifier must be between -1 and 16383
 CREATE TABLE test_qiundgkm (v1 hll(11, 5, 8589934592));
 
 -- ----------------------------------------------------------------


### PR DESCRIPTION
Before fix in `multiset_unpack()`:
![image](https://user-images.githubusercontent.com/17427025/65743994-8010bc80-e129-11e9-9da2-ab0ddb9fdb4a.png)
After fix:
![image](https://user-images.githubusercontent.com/17427025/65744013-8bfc7e80-e129-11e9-9ad5-0d359e5040a0.png)
The hlltest.sql is [here](http://blog.hidva.com/assets/hlltest.sql)

Before fix in `check_modifiers()`:
![image](https://user-images.githubusercontent.com/17427025/65744084-cbc36600-e129-11e9-93c7-e1888fede73c.png)
After fix:
![image](https://user-images.githubusercontent.com/17427025/65744097-d7af2800-e129-11e9-9f28-bee10f2acf3e.png)


```
$pg_config 
BINDIR = /home/pg/pgbin/bin
DOCDIR = /home/pg/pgbin/share/doc/postgresql
HTMLDIR = /home/pg/pgbin/share/doc/postgresql
INCLUDEDIR = /home/pg/pgbin/include
PKGINCLUDEDIR = /home/pg/pgbin/include/postgresql
INCLUDEDIR-SERVER = /home/pg/pgbin/include/postgresql/server
LIBDIR = /home/pg/pgbin/lib
PKGLIBDIR = /home/pg/pgbin/lib/postgresql
LOCALEDIR = /home/pg/pgbin/share/locale
MANDIR = /home/pg/pgbin/share/man
SHAREDIR = /home/pg/pgbin/share/postgresql
SYSCONFDIR = /home/pg/pgbin/etc/postgresql
PGXS = /home/pg/pgbin/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--enable-cassert' '--prefix=/home/pg/pgbin' '--enable-debug' 'CFLAGS=-O0 -fsanitize=address' 'LDFLAGS=-fsanitize=address'
CC = gcc
CPPFLAGS = -D_GNU_SOURCE
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -O0 -fsanitize=address
CFLAGS_SL = -fPIC
LDFLAGS = -fsanitize=address -Wl,--as-needed -Wl,-rpath,'/home/pg/pgbin/lib',--enable-new-dtags
LDFLAGS_EX = 
LDFLAGS_SL = 
LIBS = -lpgcommon -lpgport -lz -lreadline -lrt -lcrypt -ldl -lm 
VERSION = PostgreSQL 9.6.15
```
