### PR TITLE
Do not require shared_preload_libraries

### DIFF
--- a/src/hll.c
+++ b/src/hll.c
@@ -154,13 +154,6 @@ void _PG_fini(void);
 /* _PG_init is the shared library initialization function */
 void _PG_init(void)
 {
-	if (!process_shared_preload_libraries_in_progress)
-	{
-		ereport(ERROR, (errmsg("HLL can only be loaded via shared_preload_libraries"),
-						errhint("Add hll to shared_preload_libraries configuration "
-								"variable in postgresql.conf")));
-	}
-
 	/*
 	 * Register HLL configuration variables.
 	 */


### PR DESCRIPTION
hll does not need to be in shared_preload_libraries since it gets automatically loaded when an HLL function is used.

I verified that the hook is set and called as soon as an HLL function is used in a query.