### PR TITLE
Fix checkinstall for digits in float output

### DIFF
--- a/expected/card_op.out
+++ b/expected/card_op.out
@@ -1,6 +1,7 @@
 -- ----------------------------------------------------------------
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/card_op_0.out
+++ b/expected/card_op_0.out
@@ -1,6 +1,7 @@
 -- ----------------------------------------------------------------
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_add_cardinality_correction.out
+++ b/expected/cumulative_add_cardinality_correction.out
@@ -1,6 +1,7 @@
 -- ================================================================
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_add_comprehensive_promotion.out
+++ b/expected/cumulative_add_comprehensive_promotion.out
@@ -1,6 +1,7 @@
 -- ================================================================
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_union_probabilistic_probabilistic.out
+++ b/expected/cumulative_union_probabilistic_probabilistic.out
@@ -1,5 +1,6 @@
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/scalar_oob.out
+++ b/expected/scalar_oob.out
@@ -3,6 +3,7 @@
 -- NULL, UNDEFINED, EMPTY, EXPLICIT, SPARSE
 -- (Sparse and compressed are the same internally)
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/sql/card_op.sql
+++ b/sql/card_op.sql
@@ -2,6 +2,7 @@
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 SELECT #E'\\x108b49'::hll;

--- a/sql/cumulative_add_cardinality_correction.sql
+++ b/sql/cumulative_add_cardinality_correction.sql
@@ -2,6 +2,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- This test relies on a non-standard fixed sparse-to-compressed

--- a/sql/cumulative_add_comprehensive_promotion.sql
+++ b/sql/cumulative_add_comprehensive_promotion.sql
@@ -2,6 +2,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- This test relies on a non-standard fixed sparse-to-compressed

--- a/sql/cumulative_union_probabilistic_probabilistic.sql
+++ b/sql/cumulative_union_probabilistic_probabilistic.sql
@@ -1,6 +1,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 DROP TABLE IF EXISTS test_mpuahgwy;

--- a/sql/scalar_oob.sql
+++ b/sql/scalar_oob.sql
@@ -4,6 +4,7 @@
 -- (Sparse and compressed are the same internally)
 -- ----------------------------------------------------------------
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- Scalar Cardinality ----


### PR DESCRIPTION
As mentioned in issue #86, extra_float_digits=0 should be put
into the regression tests themselves, not just in Travis.