### PR TITLE
V13 table open

### DIFF
--- a/expected/card_op.out
+++ b/expected/card_op.out
@@ -1,6 +1,7 @@
 -- ----------------------------------------------------------------
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/card_op_0.out
+++ b/expected/card_op_0.out
@@ -1,6 +1,7 @@
 -- ----------------------------------------------------------------
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_add_cardinality_correction.out
+++ b/expected/cumulative_add_cardinality_correction.out
@@ -1,6 +1,7 @@
 -- ================================================================
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_add_comprehensive_promotion.out
+++ b/expected/cumulative_add_comprehensive_promotion.out
@@ -1,6 +1,7 @@
 -- ================================================================
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/cumulative_union_probabilistic_probabilistic.out
+++ b/expected/cumulative_union_probabilistic_probabilistic.out
@@ -1,5 +1,6 @@
 -- Setup the table
 --
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/expected/scalar_oob.out
+++ b/expected/scalar_oob.out
@@ -3,6 +3,7 @@
 -- NULL, UNDEFINED, EMPTY, EXPLICIT, SPARSE
 -- (Sparse and compressed are the same internally)
 -- ----------------------------------------------------------------
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
  hll_set_output_version 
 ------------------------

--- a/sql/card_op.sql
+++ b/sql/card_op.sql
@@ -2,6 +2,7 @@
 -- Regression tests for cardinality operator.
 -- ----------------------------------------------------------------
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 SELECT #E'\\x108b49'::hll;

--- a/sql/cumulative_add_cardinality_correction.sql
+++ b/sql/cumulative_add_cardinality_correction.sql
@@ -2,6 +2,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- This test relies on a non-standard fixed sparse-to-compressed

--- a/sql/cumulative_add_comprehensive_promotion.sql
+++ b/sql/cumulative_add_comprehensive_promotion.sql
@@ -2,6 +2,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- This test relies on a non-standard fixed sparse-to-compressed

--- a/sql/cumulative_union_probabilistic_probabilistic.sql
+++ b/sql/cumulative_union_probabilistic_probabilistic.sql
@@ -1,6 +1,7 @@
 -- Setup the table
 --
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 DROP TABLE IF EXISTS test_mpuahgwy;

--- a/sql/scalar_oob.sql
+++ b/sql/scalar_oob.sql
@@ -4,6 +4,7 @@
 -- (Sparse and compressed are the same internally)
 -- ----------------------------------------------------------------
 
+set extra_float_digits=0;
 SELECT hll_set_output_version(1);
 
 -- Scalar Cardinality ----

--- a/src/hll.c
+++ b/src/hll.c
@@ -301,7 +301,7 @@ get_extension_schema(Oid ext_oid)
 
 	systable_endscan(scandesc);
 
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 130000
 	table_close(rel, AccessShareLock);
 #else
 	heap_close(rel, AccessShareLock);

--- a/src/hll.c
+++ b/src/hll.c
@@ -273,7 +273,11 @@ get_extension_schema(Oid ext_oid)
 	HeapTuple	tuple;
 	ScanKeyData entry[1];
 
+#if PG_VERSION_NUM >= 130000
+	rel = table_open(ExtensionRelationId, AccessShareLock);
+#else
 	rel = heap_open(ExtensionRelationId, AccessShareLock);
+#endif
 
 	ScanKeyInit(&entry[0],
 #if PG_VERSION_NUM >= 120000
@@ -297,7 +301,11 @@ get_extension_schema(Oid ext_oid)
 
 	systable_endscan(scandesc);
 
+#if PG_VERSION_NUM >= 120000
+	table_close(rel, AccessShareLock);
+#else
 	heap_close(rel, AccessShareLock);
+#endif
 
 	return result;
 }


### PR DESCRIPTION
v12's pluggable storage added table_open, but kept heap_open as a shim
for backwards compatibility.  But v13 removed heap_open, so add
conditional compilation to make v13 work.