### PR TITLE
Round hll cardinality results to 10 decimal places

### DIFF
--- a/expected/cumulative_add_cardinality_correction.out
+++ b/expected/cumulative_add_cardinality_correction.out
@@ -56,13 +56,13 @@ SELECT curr.recno,
   FROM test_msgfjqhm prev, test_msgfjqhm curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.cardinality != 
-       hll_cardinality(hll_add(prev.union_compressed_multiset,
-                       hll_hashval(curr.raw_value)))
+   AND round(curr.cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_add(prev.union_compressed_multiset,
+                             hll_hashval(curr.raw_value)))::numeric,
+             10)
  ORDER BY curr.recno;
- recno |   cardinality    | hll_cardinality  
--------+------------------+------------------
-  1792 | 4250.71186178904 | 4250.71186178904
-(1 row)
+ recno | cardinality | hll_cardinality 
+-------+-------------+-----------------
+(0 rows)
 
 DROP TABLE test_msgfjqhm;

--- a/expected/cumulative_add_comprehensive_promotion.out
+++ b/expected/cumulative_add_comprehensive_promotion.out
@@ -56,27 +56,13 @@ SELECT curr.recno,
   FROM test_ptwysrqk prev, test_ptwysrqk curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.cardinality != 
-       hll_cardinality(hll_add(prev.union_compressed_multiset,
-                       curr.raw_value::hll_hashval))
+   AND round(curr.cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_add(prev.union_compressed_multiset,
+                             curr.raw_value::hll_hashval))::numeric,
+             10)
  ORDER BY curr.recno;
- recno |   cardinality    | hll_cardinality  
--------+------------------+------------------
-  4343 | 4250.71186178904 | 4250.71186178904
-  4344 | 4250.71186178904 | 4250.71186178904
-  4345 | 4250.71186178904 | 4250.71186178904
-  4346 | 4250.71186178904 | 4250.71186178904
-  4347 | 4250.71186178904 | 4250.71186178904
-  4348 | 4250.71186178904 | 4250.71186178904
-  4349 | 4250.71186178904 | 4250.71186178904
-  4350 | 4250.71186178904 | 4250.71186178904
-  4351 | 4250.71186178904 | 4250.71186178904
-  4352 | 4250.71186178904 | 4250.71186178904
-  4353 | 4250.71186178904 | 4250.71186178904
-  4354 | 4250.71186178904 | 4250.71186178904
-  4355 | 4250.71186178904 | 4250.71186178904
-  4356 | 4250.71186178904 | 4250.71186178904
-  4357 | 4250.71186178904 | 4250.71186178904
-(15 rows)
+ recno | cardinality | hll_cardinality 
+-------+-------------+-----------------
+(0 rows)
 
 DROP TABLE test_ptwysrqk;

--- a/expected/cumulative_union_sparse_promotion.out
+++ b/expected/cumulative_union_sparse_promotion.out
@@ -51,7 +51,8 @@ SELECT recno,
        union_cardinality,
        hll_cardinality(union_compressed_multiset)
   FROM test_bsnvqefe
- WHERE union_cardinality != hll_cardinality(union_compressed_multiset)
+ WHERE round(union_cardinality::numeric, 10) !=
+       round(hll_cardinality(union_compressed_multiset)::numeric, 10)
  ORDER BY recno;
  recno | union_cardinality | hll_cardinality 
 -------+-------------------+-----------------
@@ -81,9 +82,10 @@ SELECT curr.recno,
   FROM test_bsnvqefe prev, test_bsnvqefe curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.union_cardinality != 
-       hll_cardinality(hll_union(curr.compressed_multiset,
-                                 prev.union_compressed_multiset))
+   AND round(curr.union_cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_union(curr.compressed_multiset,
+                                       prev.union_compressed_multiset))::numeric,
+            10)
  ORDER BY curr.recno;
  recno | union_cardinality | hll_cardinality 
 -------+-------------------+-----------------

--- a/sql/cumulative_add_cardinality_correction.sql
+++ b/sql/cumulative_add_cardinality_correction.sql
@@ -44,9 +44,10 @@ SELECT curr.recno,
   FROM test_msgfjqhm prev, test_msgfjqhm curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.cardinality != 
-       hll_cardinality(hll_add(prev.union_compressed_multiset,
-                       hll_hashval(curr.raw_value)))
+   AND round(curr.cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_add(prev.union_compressed_multiset,
+                             hll_hashval(curr.raw_value)))::numeric,
+             10)
  ORDER BY curr.recno;
 
 DROP TABLE test_msgfjqhm;

--- a/sql/cumulative_add_comprehensive_promotion.sql
+++ b/sql/cumulative_add_comprehensive_promotion.sql
@@ -44,9 +44,10 @@ SELECT curr.recno,
   FROM test_ptwysrqk prev, test_ptwysrqk curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.cardinality != 
-       hll_cardinality(hll_add(prev.union_compressed_multiset,
-                       curr.raw_value::hll_hashval))
+   AND round(curr.cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_add(prev.union_compressed_multiset,
+                             curr.raw_value::hll_hashval))::numeric,
+             10)
  ORDER BY curr.recno;
 
 DROP TABLE test_ptwysrqk;

--- a/sql/cumulative_union_sparse_promotion.sql
+++ b/sql/cumulative_union_sparse_promotion.sql
@@ -39,7 +39,8 @@ SELECT recno,
        union_cardinality,
        hll_cardinality(union_compressed_multiset)
   FROM test_bsnvqefe
- WHERE union_cardinality != hll_cardinality(union_compressed_multiset)
+ WHERE round(union_cardinality::numeric, 10) !=
+       round(hll_cardinality(union_compressed_multiset)::numeric, 10)
  ORDER BY recno;
 
 -- Test union of incremental multiset.
@@ -63,9 +64,10 @@ SELECT curr.recno,
   FROM test_bsnvqefe prev, test_bsnvqefe curr
  WHERE curr.recno > 1
    AND curr.recno = prev.recno + 1
-   AND curr.union_cardinality != 
-       hll_cardinality(hll_union(curr.compressed_multiset,
-                                 prev.union_compressed_multiset))
+   AND round(curr.union_cardinality::numeric, 10) != 
+       round(hll_cardinality(hll_union(curr.compressed_multiset,
+                                       prev.union_compressed_multiset))::numeric,
+            10)
  ORDER BY curr.recno;
 
 -- Test aggregate accumulation


### PR DESCRIPTION
Some test outputs are different on some recent debian flavored distros due to [glibc new log()](https://sourceware.org/git/?p=glibc.git;a=commit;h=f41b0a43e426831e391cafd8d0bd47a3efa4a840) implementation which gives a slightly different precision.

This PR rounds all hll cardinality results in the regression tests to 10 decimal places to make sure our tests produce the same expected results across different architectures.

I reproduced the issue on a Ubuntu Focal VM with glibc version 2.31, and confirmed that the tests pass after my changes.

Fixes: #67 