### PR TITLE
Bump hll to 2.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: bionic
+dist: focal
 language: c
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2020-12-08
+==========
+v2.15.1
+- [PR #112](https://github.com/citusdata/postgresql-hll/pull/112), Fixes tests on glibc>=2.29
+
 2020-11-26
 ==========
 v2.15


### PR DESCRIPTION
We fixed broken tests on recent glibc versions (#67) on #112. I plan to create a new tag v2.15.1 that contains this fix.

To make sure that we do not regress in the future, I also updated our regression suite to use ubuntu focal running on glibc 2.31. To verify that #112 actually solved our problems, see the failed tests on https://github.com/citusdata/postgresql-hll/commit/c42fc1ab30d172100a65cc543eaed6d4031d8862