### PR TITLE
Document compatibility for latest Postgres versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Compatibility
 
 This module has been tested on:
 
-* **Postgres 9.4, 9.5, 9.6, 10, 11**
+* **Postgres 9.4, 9.5, 9.6, 10, 11, 12, 13**
 
 If you end up needing to change something to get this running on another system, send us the diff and we'll try to work it in!
 


### PR DESCRIPTION
I noticed that these versions were missing from the README even though the changelog documents compatibility with the latest versions.