### PR TITLE
PostgreSQL 14 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Compatibility
 
 This module has been tested on:
 
-* **Postgres 9.4, 9.5, 9.6, 10, 11, 12, 13**
+* **Postgres 9.4, 9.5, 9.6, 10, 11, 12, 13, 14**
 
 If you end up needing to change something to get this running on another system, send us the diff and we'll try to work it in!
 

--- a/src/hll.c
+++ b/src/hll.c
@@ -328,10 +328,18 @@ FunctionOid(const char *schemaName, const char *functionName, int argumentCount,
 	List *argumentList = NIL;
 	const bool findVariadics = false;
 	const bool findDefaults = false;
+#if PG_VERSION_NUM >= 140000
+	const bool includeOutArguments = false;
 
 	functionList = FuncnameGetCandidates(qualifiedFunctionNameList, argumentCount,
 										 argumentList, findVariadics,
-										 findDefaults, true);
+										 findDefaults, includeOutArguments,
+										 true);
+#else
+	functionList = FuncnameGetCandidates(qualifiedFunctionNameList, argumentCount,
+                                                                                 argumentList, findVariadics,
+                                                                                 findDefaults, true);
+#endif
 
 	if (functionList == NULL)
 	{


### PR DESCRIPTION
Starting from PostgreSQL 14, the `FuncnameGetCandidates` function requires one more bool parameter to control whether OUT-mode arguments are ignored or not.