### PR TITLE
Add notes on not having dev files in certain Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,16 @@ Then install:
 
         sudo make install
 
+### Troubleshooting source install ###
+
+You need postgresql's libraries and headers for C lang available in order to
+install from source. If you don't have these, you may encounter `No such file
+or directory` errors and will not be able to run the `make` step above. This
+step may depend on your OS but to install them on Debian variants use you may
+use:
+
+        sudo apt-get install postgresql-server-dev-<YOUR_VERSION>
+
 Install
 =======
 


### PR DESCRIPTION
I'm on Ubuntu 20.04.4 and noticed I didn't have the dev tools available when installing from source. [This comment pointed me to the right direction](https://github.com/citusdata/postgresql-hll/issues/71#issuecomment-492217409) so I figured others may benefit from it as well.

Thank you for your work! Hope this helps.