### PR TITLE
Stop generating migration files for each version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ regression.diffs
 results
 .deps/
 
-hll--*.*.sql
-!update/hll--*.*.sql
+/*.sql

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 EXTENSION = hll
-EXTVERSIONS = 2.10 2.11 2.12 2.13 2.14 2.15 2.16
-
-DATA_built = $(foreach v,$(EXTVERSIONS),$(EXTENSION)--$(v).sql) $(wildcard $(EXTENSION)--*--*.sql)
+sql_files = $(wildcard update/$(EXTENSION)--*.sql)
+generated_sql_files = $(patsubst update/%,%,$(sql_files))
+DATA_built = $(generated_sql_files)
 
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c)) $(patsubst %.cpp,%.o,$(wildcard src/*.cpp))
@@ -34,16 +34,3 @@ src/hll.o: override CFLAGS += -std=c99
 
 %.sql: update/%.sql
 	$(SQLPP) $^ > $@
-
-$(EXTENSION)--2.11.sql: $(EXTENSION)--2.10.sql $(EXTENSION)--2.10--2.11.sql
-	cat $^ > $@
-$(EXTENSION)--2.12.sql: $(EXTENSION)--2.11.sql $(EXTENSION)--2.11--2.12.sql
-	cat $^ > $@
-$(EXTENSION)--2.13.sql: $(EXTENSION)--2.12.sql $(EXTENSION)--2.12--2.13.sql
-	cat $^ > $@
-$(EXTENSION)--2.14.sql: $(EXTENSION)--2.13.sql $(EXTENSION)--2.13--2.14.sql
-	cat $^ > $@
-$(EXTENSION)--2.15.sql: $(EXTENSION)--2.14.sql $(EXTENSION)--2.14--2.15.sql
-	cat $^ > $@
-$(EXTENSION)--2.16.sql: $(EXTENSION)--2.15.sql $(EXTENSION)--2.15--2.16.sql
-	cat $^ > $@


### PR DESCRIPTION
PostgreSQL 10 introduced an improvement on extension migration paths. We
no longer need to generate a migration file for each version. It is
sufficient to have an initial script and the migration scripts that are
used to upgrade to the next version.

This commit also fixes an issue where we did not install necessary
migration files on a clean build.

Fixes: #134 #133 