### PR TITLE
return hll_empty for no input rows in hll_add_agg

### DIFF
--- a/src/hll.c
+++ b/src/hll.c
@@ -3608,7 +3608,11 @@ hll_pack(PG_FUNCTION_ARGS)
     // Is the first argument a NULL?
     if (PG_ARGISNULL(0))
     {
-        PG_RETURN_NULL();
+        PG_RETURN_DATUM(DirectFunctionCall4(hll_empty4,
+                                            Int32GetDatum(g_default_log2m),
+                                            Int32GetDatum(g_default_regwidth),
+                                            Int64GetDatum(g_default_expthresh),
+                                            Int32GetDatum(g_default_sparseon)));
     }
     else
     {
@@ -3635,7 +3639,7 @@ hll_pack(PG_FUNCTION_ARGS)
 
             PG_RETURN_BYTEA_P(cb);
         }
-    }
+    }   
 }
 
 // Final function, computes cardinality of unpacked bytea.


### PR DESCRIPTION
When I debugged Issue #129, I observed that the state transition function, `hll_add_trans`, was not being called at all. This was because the values used in the filter did not satisfy the condition. However, I noticed that the final function, `hll_pack`, was called with a null input. In this case, I made development so that if `hll_pack` is called with a null input, it will return `hll_empty`.

`hll_pack` is the final function for `hll_union_agg` as well. With my fix, if `hll_pack` is called with a null parameter while using `hll_union_agg`, it returns `hll_empty`. This is causing the failure of this test:

_SELECT hll_union_agg(v1) FROM test_wdflbzfx WHERE recno > 100;_

Moreover, when `hll_add_agg` is directly called with null parameters, it also returns `hll_empty`, as mentioned in Issue #2. However, `hll_union_agg` returns null in such a case. Shouldn't `hll_union_agg` also return `hll_empty` when called with null parameters? What are your thoughts on this matter?

<img width="521" alt="hll_add_agg" src="https://github.com/citusdata/postgresql-hll/assets/35075862/a90f382d-8bea-49ae-9403-7b2f14c65c26">
