### PR TITLE
Update README.md for PostgreSQL 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Compatibility
 
 This module has been tested on:
 
-* **Postgres 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16**
+* **Postgres 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16, 17**
 
 If you end up needing to change something to get this running on another system, send us the diff and we'll try to work it in!
 


### PR DESCRIPTION
Added PostgreSQL 17 to the list of tested versions after running regression tests on PostgreSQL 17.
No updates were needed for the tests.