### PR TITLE
Fix build with PostgreSQL 18

### DIFF
--- a/src/hll.c
+++ b/src/hll.c
@@ -127,7 +127,7 @@ enum {
 static Oid hllAggregateArray[HLL_AGGREGATE_COUNT];
 static bool aggregateValuesInitialized = false;
 
-bool ForceGroupAgg = false;
+static bool ForceGroupAgg = false;
 
 static create_upper_paths_hook_type previous_upper_path_hook;
 static void RegisterConfigVariables(void);
@@ -2053,7 +2053,7 @@ check_modifiers(int32 log2m, int32 regwidth, int64 expthresh, int32 sparseon)
     if (expthresh < -1 || expthresh > expthresh_max)
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("expthresh modifier must be between -1 and %ld", expthresh_max)));
+                 errmsg("expthresh modifier must be between -1 and "INT64_FORMAT, expthresh_max)));
 
     if (expthresh > 0 && (1LL << integer_log2(expthresh)) != expthresh)
         ereport(ERROR,


### PR DESCRIPTION
PostgreSQL 18 added -Wmissing-variable-declarations to the default compilation flags. When combined with -Werror, this requires variables that are only used within a single C file to be marked as `static`. Without this change, builds fail due to missing variable declaration warnings being treated as errors.
Also, update format specifiers for int64 to ensure successful compilation across all supported platforms.