### PR TITLE
Support PostgreSQL 19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ include $(PGXS)
 SHLIB_LINK	+= -lstdc++
 SQLPP ?= cpp -undef -w -P -imacros $(shell $(PG_CONFIG) --includedir-server)/pg_config.h
 
-src/hll.o: override CFLAGS += -std=c99
+src/hll.o: override CFLAGS += -std=c11
 
 %.sql: update/%.sql
 	$(SQLPP) $^ > $@

--- a/expected/card_op.out
+++ b/expected/card_op.out
@@ -20,12 +20,11 @@ SELECT #hll_empty(11,5,256,1);
         0
 (1 row)
 
+\set VERBOSITY terse
 -- # gets evaluated first so || hll_union(double, bigint) fails
 SELECT #hll_empty(11,5,256,1) || hll_hash_integer(1,0);
-ERROR:  operator does not exist: double precision || hll_hashval
-LINE 1: SELECT #hll_empty(11,5,256,1) || hll_hash_integer(1,0);
-                                      ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  operator does not exist: double precision || hll_hashval at character 31
+\set VERBOSITY default
 SELECT #(hll_empty(11,5,256,1) || hll_hash_integer(1,0));
  ?column? 
 ----------

--- a/expected/hash.out
+++ b/expected/hash.out
@@ -176,11 +176,10 @@ WARNING:  negative seed values not compatible
 (1 row)
 
 -- WARNING:  negative seed values not compatible
+\set VERBOSITY terse
 SELECT hll_hash_boolean(0, -1);
-ERROR:  function hll_hash_boolean(integer, integer) does not exist
-LINE 1: SELECT hll_hash_boolean(0, -1);
-               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function hll_hash_boolean(integer, integer) does not exist at character 8
+\set VERBOSITY default
 SELECT hll_hash_smallint(0::smallint, -1);
 WARNING:  negative seed values not compatible
   hll_hash_smallint  
@@ -316,13 +315,9 @@ SELECT hll_empty() || CAST(42 AS bigint)::hll_hashval;
 (1 row)
 
 -- ERROR: doesn't cast implicitly
+\set VERBOSITY terse
 SELECT hll_empty() || 42;
-ERROR:  operator does not exist: hll || integer
-LINE 1: SELECT hll_empty() || 42;
-                           ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
+ERROR:  operator does not exist: hll || integer at character 20
 SELECT hll_empty() || 42::bigint;
-ERROR:  operator does not exist: hll || bigint
-LINE 1: SELECT hll_empty() || 42::bigint;
-                           ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
+ERROR:  operator does not exist: hll || bigint at character 20
+\set VERBOSITY default

--- a/sql/card_op.sql
+++ b/sql/card_op.sql
@@ -9,8 +9,10 @@ SELECT #E'\\x108b49'::hll;
 
 SELECT #hll_empty(11,5,256,1);
 
+\set VERBOSITY terse
 -- # gets evaluated first so || hll_union(double, bigint) fails
 SELECT #hll_empty(11,5,256,1) || hll_hash_integer(1,0);
+\set VERBOSITY default
 
 SELECT #(hll_empty(11,5,256,1) || hll_hash_integer(1,0));
 

--- a/sql/hash.sql
+++ b/sql/hash.sql
@@ -64,7 +64,9 @@ SELECT hll_hash_bigint(0, -2);
 SELECT hll_hash_bigint(0, -2147483648);
 
 -- WARNING:  negative seed values not compatible
+\set VERBOSITY terse
 SELECT hll_hash_boolean(0, -1);
+\set VERBOSITY default
 SELECT hll_hash_smallint(0::smallint, -1);
 SELECT hll_hash_integer(0, -1);
 SELECT hll_hash_bigint(0, -1);
@@ -97,6 +99,7 @@ SELECT hll_empty() || 42::bigint::hll_hashval;
 SELECT hll_empty() || CAST(42 AS bigint)::hll_hashval;
 
 -- ERROR: doesn't cast implicitly
+\set VERBOSITY terse
 SELECT hll_empty() || 42;
 SELECT hll_empty() || 42::bigint;
-
+\set VERBOSITY default

--- a/src/hll.c
+++ b/src/hll.c
@@ -234,7 +234,7 @@ hll_aggregation_restriction_hook(PlannerInfo *root, UpperRelationKind stage,
  * InitializeHllAggregateOids initializes the array of hll aggregate oids.
  */
 static void
-InitializeHllAggregateOids()
+InitializeHllAggregateOids(void)
 {
 	Oid extensionId = get_extension_oid(EXTENSION_NAME, false);
 	Oid hllSchemaOid = get_extension_schema(extensionId);
@@ -336,7 +336,15 @@ FunctionOid(const char *schemaName, const char *functionName, int argumentCount,
 	List *argumentList = NIL;
 	const bool findVariadics = false;
 	const bool findDefaults = false;
-#if PG_VERSION_NUM >= 140000
+#if PG_VERSION_NUM >= 190000
+	const bool includeOutArguments = false;
+	int fgcFlags = 0;
+
+	functionList = FuncnameGetCandidates(qualifiedFunctionNameList, argumentCount,
+										 argumentList, findVariadics,
+										 findDefaults, includeOutArguments,
+										 true, &fgcFlags);
+#elif PG_VERSION_NUM >= 140000
 	const bool includeOutArguments = false;
 
 	functionList = FuncnameGetCandidates(qualifiedFunctionNameList, argumentCount,


### PR DESCRIPTION
- require c11 instead of c99
- FuncnameGetCandidates() changed signature
- Fixed regression tests failures caused by changes in ERROR output when function/operator is missing by switching VERBOSITY to terse and back.