### PR TITLE
Harden multiset_unpack and hll_deserialize input validation

### DIFF
--- a/expected/explicit_threshold_cap.out
+++ b/expected/explicit_threshold_cap.out
@@ -270,10 +270,10 @@ CREATE TEMPORARY TABLE hll_parallel_test AS
 ANALYZE hll_parallel_test;
 -- Non-parallel baseline.
 SET max_parallel_workers_per_gather = 0;
-SELECT hll_cardinality(hll_union_agg(h)) AS card_serial FROM hll_parallel_test;
-    card_serial    
--------------------
- 999.7020724616214
+SELECT round(hll_cardinality(hll_union_agg(h))::numeric, 5) AS card_serial FROM hll_parallel_test;
+ card_serial 
+-------------
+   999.70207
 (1 row)
 
 -- Force parallel execution to exercise hll_serialize/hll_deserialize.
@@ -281,10 +281,10 @@ SET max_parallel_workers_per_gather = 2;
 SET parallel_tuple_cost = 0;
 SET parallel_setup_cost = 0;
 SET min_parallel_table_scan_size = 0;
-SELECT hll_cardinality(hll_union_agg(h)) AS card_parallel FROM hll_parallel_test;
-   card_parallel   
--------------------
- 999.7020724616214
+SELECT round(hll_cardinality(hll_union_agg(h))::numeric, 5) AS card_parallel FROM hll_parallel_test;
+ card_parallel 
+---------------
+     999.70207
 (1 row)
 
 -- Reset.

--- a/sql/explicit_threshold_cap.sql
+++ b/sql/explicit_threshold_cap.sql
@@ -223,14 +223,14 @@ ANALYZE hll_parallel_test;
 
 -- Non-parallel baseline.
 SET max_parallel_workers_per_gather = 0;
-SELECT hll_cardinality(hll_union_agg(h)) AS card_serial FROM hll_parallel_test;
+SELECT round(hll_cardinality(hll_union_agg(h))::numeric, 5) AS card_serial FROM hll_parallel_test;
 
 -- Force parallel execution to exercise hll_serialize/hll_deserialize.
 SET max_parallel_workers_per_gather = 2;
 SET parallel_tuple_cost = 0;
 SET parallel_setup_cost = 0;
 SET min_parallel_table_scan_size = 0;
-SELECT hll_cardinality(hll_union_agg(h)) AS card_parallel FROM hll_parallel_test;
+SELECT round(hll_cardinality(hll_union_agg(h))::numeric, 5) AS card_parallel FROM hll_parallel_test;
 
 -- Reset.
 RESET max_parallel_workers_per_gather;

--- a/src/hll.c
+++ b/src/hll.c
@@ -525,6 +525,7 @@ static int32 encode_expthresh(int64 expthresh)
 
 static size_t mse_nelem_max(void);
 static void check_modifiers(int32 log2m, int32 regwidth, int64 expthresh, int32 sparseon);
+static void check_unpacked_modifiers(int32 log2m, int32 regwidth, int64 expthresh, int32 sparseon);
 // If expthresh == -1 (auto select expthresh) determine
 // the expthresh to use from nbits and nregs.
 //
@@ -1493,16 +1494,22 @@ multiset_unpack(multiset_t * o_msp,
         if (vers == 1)
         {
             size_t hdrsz = 3;
+            size_t nbits;
+            size_t nregs;
+            size_t bitsz;
+            size_t packedbytesz;
 
-            // Decode the parameter byte.
-            uint8_t param = i_bitp[1];
-            size_t nbits = (param >> 5) + 1;
-            size_t log2nregs = param & 0x1f;
-            size_t nregs = 1 << log2nregs;
+            unpack_header(o_msp, i_bitp, vers, type);
+
+            check_unpacked_modifiers(o_msp->ms_log2nregs, o_msp->ms_nbits,
+                                     o_msp->ms_expthresh, o_msp->ms_sparseon);
+
+            nbits = o_msp->ms_nbits;
+            nregs = o_msp->ms_nregs;
 
             // Make sure the size is consistent.
-            size_t bitsz = nbits * nregs;
-            size_t packedbytesz = (bitsz + 7) / 8;
+            bitsz = nbits * nregs;
+            packedbytesz = (bitsz + 7) / 8;
             if ((i_size - hdrsz) != packedbytesz)
             {
                 ereport(ERROR,
@@ -1518,8 +1525,6 @@ multiset_unpack(multiset_t * o_msp,
                         (errcode(ERRCODE_DATA_EXCEPTION),
                          errmsg("compressed multiset too large")));
             }
-
-            unpack_header(o_msp, i_bitp, vers, type);
 
             // Fill the registers.
             compressed_unpack(o_msp->ms_data.as_comp.msc_regs,
@@ -1549,6 +1554,9 @@ multiset_unpack(multiset_t * o_msp,
             }
 
             unpack_header(o_msp, i_bitp, vers, type);
+
+            check_unpacked_modifiers(o_msp->ms_log2nregs, o_msp->ms_nbits,
+                                     o_msp->ms_expthresh, o_msp->ms_sparseon);
         }
         else
         {
@@ -1575,20 +1583,31 @@ multiset_unpack(multiset_t * o_msp,
             }
             else
             {
-                // Decode the parameter byte.
-                uint8_t param = i_bitp[1];
-                size_t nbits = (param >> 5) + 1;
-                size_t log2nregs = param & 0x1f;
-                size_t nregs = 1 << log2nregs;
+                size_t nbits;
+                size_t log2nregs;
+                size_t nregs;
+                size_t bitsz;
+                size_t chunksz;
+                size_t nfilled;
+                size_t ii;
+
+                unpack_header(o_msp, i_bitp, vers, type);
+
+                check_unpacked_modifiers(o_msp->ms_log2nregs, o_msp->ms_nbits,
+                                         o_msp->ms_expthresh, o_msp->ms_sparseon);
+
+                nbits = o_msp->ms_nbits;
+                log2nregs = o_msp->ms_log2nregs;
+                nregs = o_msp->ms_nregs;
 
                 // Figure out how many encoded registers are in the
                 // bitstream.  We depend on the log2nregs + nbits being
                 // greater then the pad size so we aren't left with
                 // ambiguity in the final pad byte.
 
-                size_t bitsz = (i_size - hdrsz) * 8;
-                size_t chunksz = log2nregs + nbits;
-                size_t nfilled = bitsz / chunksz;
+                bitsz = (i_size - hdrsz) * 8;
+                chunksz = log2nregs + nbits;
+                nfilled = bitsz / chunksz;
 
                 // Make sure the compressed array fits in memory.
                 if (nregs * sizeof(compreg_t) > MS_MAXDATA)
@@ -1598,14 +1617,12 @@ multiset_unpack(multiset_t * o_msp,
                              errmsg("sparse multiset too large")));
                 }
 
-                unpack_header(o_msp, i_bitp, vers, type);
-
                 mscp = &o_msp->ms_data.as_comp;
 
                 // Pre-zero the registers since sparse only fills
                 // in occasional ones.
                 //
-                for (size_t ii = 0; ii < nregs; ++ii)
+                for (ii = 0; ii < nregs; ++ii)
                     mscp->msc_regs[ii] = 0;
 
                 // Fill the registers.
@@ -2076,6 +2093,45 @@ check_modifiers(int32 log2m, int32 regwidth, int64 expthresh, int32 sparseon)
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("expthresh modifier must be between -1 and "INT64_FORMAT, expthresh_max)));
+
+    if (expthresh > 0 && (1LL << integer_log2(expthresh)) != expthresh)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("expthresh modifier must be power of 2")));
+
+    if (sparseon < 0 || sparseon > MAX_BITVAL(SPARSEON_BITS))
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("sparseon modifier must be 0 or 1")));
+}
+
+// Relaxed modifier validation for deserialized data.
+// Like check_modifiers but allows expthresh values above mse_nelem_max()
+// that may exist in data written before the capacity cap was introduced.
+// The runtime expthresh_value() already clamps the effective threshold.
+//
+static void
+check_unpacked_modifiers(int32 log2m, int32 regwidth, int64 expthresh, int32 sparseon)
+{
+    int32 log2m_max = integer_log2(msc_regs_idx_limit());
+
+    if (log2m < 0 || log2m > log2m_max)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("log2m modifier must be between 0 and %d", log2m_max)));
+
+    if (regwidth < 0 || regwidth > MAX_BITVAL(REGWIDTH_BITS))
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("regwidth modifier must be between 0 and 7")));
+
+    // Accept any value that decode_expthresh can produce: -1, 0,
+    // or a positive power of two.  The mse_nelem_max() cap is
+    // enforced at runtime in expthresh_value().
+    if (expthresh < -1)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("expthresh modifier must be >= -1")));
 
     if (expthresh > 0 && (1LL << integer_log2(expthresh)) != expthresh)
         ereport(ERROR,
@@ -3892,16 +3948,25 @@ hll_deserialize(PG_FUNCTION_ARGS)
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("hll_deserialize outside transition context")));
 
-    multiSet = palloc(sizeof(multiset_t));
-
     multiSetSize = VARSIZE(serializedBytes) - VARHDRSZ;
+
+    if (multiSetSize < __builtin_offsetof(multiset_t, ms_data))
+        ereport(ERROR,
+                (errcode(ERRCODE_DATA_EXCEPTION),
+                 errmsg("deserialized HLL state is truncated")));
 
     if (multiSetSize > sizeof(multiset_t))
         ereport(ERROR,
                 (errcode(ERRCODE_DATA_EXCEPTION),
                  errmsg("deserialized HLL exceeds maximum multiset size")));
 
+    multiSet = palloc0(sizeof(multiset_t));
     memcpy(multiSet, VARDATA(serializedBytes), multiSetSize);
+
+    if (multiset_copy_size(multiSet) != multiSetSize)
+        ereport(ERROR,
+                (errcode(ERRCODE_DATA_EXCEPTION),
+                 errmsg("deserialized HLL state has inconsistent size")));
 
     PG_RETURN_POINTER(multiSet);
 }


### PR DESCRIPTION
multiset_unpack(): The COMPRESSED, SPARSE, and UNDEFINED branches decoded header parameters manually and only validated size/capacity constraints. Move unpack_header() before the downstream checks so the struct fields are used directly (removing duplicated parameter-byte decoding), and add check_unpacked_modifiers() after every unpack_header() call to validate log2m, regwidth, expthresh, and sparseon in all branches, not just EMPTY and EXPLICIT.

Introduce check_unpacked_modifiers() as a relaxed variant of check_modifiers() for the deserialization path: it validates the same parameter ranges but does not cap expthresh at mse_nelem_max(), since compressed/sparse/undefined representations may legitimately store larger values from earlier versions.  The runtime expthresh_value() already clamps the effective threshold.

hll_deserialize(): Add a minimum-size check to reject payloads smaller than the fixed header, switch from palloc() to palloc0() so uncopied tail bytes are deterministically zero, and verify that multiset_copy_size() matches the received payload size to catch inconsistent internal state.

Round the cardinality output in parallel-aggregation regression test to 5 decimal places to avoid platform-dependent floating-point formatting differences.